### PR TITLE
fix(is): JSONType allowed numbers as JSON keys

### DIFF
--- a/packages/is/src/lib/isJSON.ts
+++ b/packages/is/src/lib/isJSON.ts
@@ -14,7 +14,7 @@ export type JSONType =
   | boolean
   | null
   | JSONType[]
-  | { [key: string | number]: JSONType };
+  | { [key: string]: JSONType };
 
 /**
  * Is the value a valid JSON value?


### PR DESCRIPTION
jsontype was allowing numbers as json keys which is not correct

fix #31